### PR TITLE
コードレビューのお願い【商品詳細表示機能】

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,6 +13,9 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+  def show
+    @item=Item.find(params[:id])
+  end
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,34 +7,37 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "#{@item.item_price}円" %>
       </span>
       <span class="item-postage">
         <%= '配送料負担' %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? then %>
+      <% if current_user.id == @item.user_id  then %>
+      
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +46,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.item_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_sales_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.item_shipping_fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.item_prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.item_scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +106,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href=“#” class=‘another-item’><%= @item.item_category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
@@ -19,7 +19,7 @@
         <%= "#{@item.item_price}円" %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.item_shipping_fee_status.name %>
       </span>
     </div>
 
@@ -40,7 +40,7 @@
 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_info %></span>
     </div>
     <table class="detail-table">
       <tbody>


### PR DESCRIPTION
# What
Itemsコントローラーにshowアクションを設定し、
Itemsビューにおいて、
ログイン状態にかかわらず、
出品情報を閲覧できるようにしました。
また、ログイン者が出品者の場合、
編集、削除ボタンを表示し、
ログイン者が出品者以外の場合は、
購入ボタンが表示するようにしました。

なお、商品購入機能が未実装なため、以下の2つの実装が未完了です。
・売却済みの商品の画像上に『sold out』と表示。
・商品売却済の場合、購入ボタンを非表示。

# Why
出品者のみ編集削除ができ、
ログイン者かつ出品者以外が購入できるようにするため。

以下がGyazoGifとなります。
１。未ログイン者から見た、商品詳細画面
https://gyazo.com/1ea6f8b96835cbec4d19b5c5d98ebaa9
２。ログイン者かつ、出品者から見た商品詳細画面
https://gyazo.com/50e29dd226449ac93baaea6c625dc9bf
３。ログイン者かつ、出品者以外から見た商品詳細画面
https://gyazo.com/69018ee44b12b7b4182e01fd53cc2c49

お手数おかけしますが、ご確認のほど宜しくお願いいたします。
